### PR TITLE
Use old-releases.ubuntu.com in Ubuntu containers

### DIFF
--- a/docker/ubuntu-12.04/Dockerfile
+++ b/docker/ubuntu-12.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   m4
 
-RUN git clone https://github.com/fbenz/FpDebug.git
+RUN git clone https://github.com/friedc/FpDebug.git
 
 WORKDIR /FpDebug
 

--- a/docker/ubuntu-12.04/Dockerfile
+++ b/docker/ubuntu-12.04/Dockerfile
@@ -1,6 +1,8 @@
 # FpDebug with Valgrind 3.7 on Ubuntu 12.04
 FROM ubuntu:12.04
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
   git \
   bzip2 \

--- a/docker/ubuntu-12.04/Dockerfile
+++ b/docker/ubuntu-12.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   m4
 
-RUN git clone https://github.com/friedc/FpDebug.git
+RUN git clone https://github.com/fbenz/FpDebug.git
 
 WORKDIR /FpDebug
 

--- a/docker/ubuntu-16.10/Dockerfile
+++ b/docker/ubuntu-16.10/Dockerfile
@@ -1,6 +1,8 @@
 # FpDebug with Valgrind 3.12 on Ubuntu 16.10
 FROM ubuntu:16.10
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
   git \
   bzip2 \

--- a/valgrind/configure_updated
+++ b/valgrind/configure_updated
@@ -5365,7 +5365,7 @@ $as_echo_n "checking for the kernel version... " >&6; }
         kernel=`uname -r`
 
         case "${kernel}" in
-             2.6.*|3.*|4.*)
+             2.6.*|3.*|4.*|5.*)
         	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 2.6.x/3.x family (${kernel})" >&5
 $as_echo "2.6.x/3.x family (${kernel})" >&6; }
 


### PR DESCRIPTION
Releases which are end of life can only be accessed through old-releases.ubuntu.com. See:

* https://ubuntu.com/about/release-cycle
* https://help.ubuntu.com/community/EOLUpgrades.